### PR TITLE
Temporarily hide the donate link and about section

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -21,9 +21,9 @@ export default function About() {
       <Box id={"book-a-presentation"}>
         <LearnMore />
       </Box>
-      <Box id={"donate"}>
+      {/* <Box id={"donate"}>
         <Donate />
-      </Box>
+      </Box> */}
       <Box id={"acknowledgements"}>
         <Acknowledgements />
       </Box>

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -139,7 +139,7 @@ const Footer = () => {
                     text={"Book a Presentation"}
                     href="/about#book-a-presentation"
                   />
-                  <FooterItem text={"Donate"} href="/about#donate" />
+                  {/* <FooterItem text={"Donate"} href="/about#donate" /> */}
                   <FooterItem
                     text={"Acknowledgements"}
                     href="/about#acknowledgements"

--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -226,7 +226,7 @@ const Footer = () => {
         }}
       >
         <Typography variant={"caption"} color={"Grey800"}>
-          © 2024 Ally Global Foundation
+          © {new Date().getFullYear()} Ally Global Foundation
         </Typography>
         <Box
           sx={{ display: "flex", gap: { xs: 2, sm: 2, md: 4 }, mt: "-10px" }}


### PR DESCRIPTION
We need to temporarily disable the donate link from the website. This PR changes the following:
- Hides the Donate link from the footer by commenting it out.
- Hides the Donate section from the about page by commenting it out.
- Small update I updated the footer year from 2024 to the current year using Date