### PR TITLE
17 09 2025 Update emails on website - Remove info@thepreventionproject

### DIFF
--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -177,22 +177,39 @@ const Footer = () => {
                     QUESTIONS?
                   </Typography>
                 </Box>
-                <Box gap={2} sx={{ display: "flex", flexDirection: "column" }}>
+                <Box sx={{ display: "flex", flexDirection: "column" }}>
                   <Typography
                     variant={"caption"}
                     color={`Grey800`}
                     lineHeight={"24px"}
                   >
-                    Email us at{" "}
+                    Email ExEd at{" "}
                     <Typography
                       component={"a"}
-                      href="mailto:info@thepreventionproject.ca"
+                      href="mailto:hello@exploitationeducation.org"
                       target="_blank"
                       color="Grey800"
                       variant={"caption"}
                       lineHeight={"24px"}
                     >
-                      info@thepreventionproject.ca
+                      hello@exploitationeducation.org
+                    </Typography>
+                  </Typography>
+                  <Typography
+                    variant={"caption"}
+                    color={`Grey800`}
+                    lineHeight={"24px"}
+                  >
+                    Email Ally at{" "}
+                    <Typography
+                      component={"a"}
+                      href="mailto:info@ally.org"
+                      target="_blank"
+                      color="Grey800"
+                      variant={"caption"}
+                      lineHeight={"24px"}
+                    >
+                      info@ally.org
                     </Typography>
                   </Typography>
                   <Box>

--- a/sections/ParentsAndEducators/HowToBrowse.tsx
+++ b/sections/ParentsAndEducators/HowToBrowse.tsx
@@ -91,7 +91,7 @@ const CallOutSection = () => {
 				These resources should only be used with their intended audiences, in
 				order to maintain the integrity and safety of the material. Please{' '}
 				<Link
-					href="mailto:info@thepreventionproject.ca"
+					href="mailto:info@ally.org"
 					sx={{ color: 'PrimaryPurple' }}
 				>
 					contact us

--- a/sections/ParentsAndEducators/HowToBrowse.tsx
+++ b/sections/ParentsAndEducators/HowToBrowse.tsx
@@ -89,12 +89,19 @@ const CallOutSection = () => {
 			</Text>
 			<Typography variant="body1" color="Grey800" sx={{ textAlign: 'center' }}>
 				These resources should only be used with their intended audiences, in
-				order to maintain the integrity and safety of the material. Please{' '}
+				order to maintain the integrity and safety of the material. Please contact{' '}
 				<Link
 					href="mailto:info@ally.org"
 					sx={{ color: 'PrimaryPurple' }}
 				>
-					contact us
+					Ally
+				</Link>{' '}
+				or{' '}
+				<Link
+					href="mailto:hello@exploitationeducation.org"
+					sx={{ color: 'PrimaryPurple' }}
+				>
+					ExEd
 				</Link>{' '}
 				if you wish to distribute them widely or feature them on your website.
 			</Typography>

--- a/sections/ParentsAndEducators/Questions.tsx
+++ b/sections/ParentsAndEducators/Questions.tsx
@@ -19,13 +19,19 @@ const QuestionsSection = () => {
 					We&apos;re here to help.
 				</Text>
 				<Text variant={"body1"} color={"Grey900"} sx={{ textAlign: "center" }}>
-					If you need further support, reach out to us by emailing{" "}
+					If you need further support, reach out to either{" "}
 					<Link
 						href="mailto:info@ally.org"
 						sx={{ color: "PrimaryPurple" }}
 					>
-						info@ally.org
-					</Link>{" "}
+						Ally
+					</Link>{" "} or{" "}
+					<Link
+						href="mailto:hello@exploitationeducation.org"
+						sx={{ color: "PrimaryPurple" }}
+					>
+						ExEd
+					</Link>.
 					We&apos;re committed to ensuring you feel equipped and empowered to
 					use The Prevention Project effectively.
 				</Text>

--- a/sections/ParentsAndEducators/Questions.tsx
+++ b/sections/ParentsAndEducators/Questions.tsx
@@ -21,10 +21,10 @@ const QuestionsSection = () => {
 				<Text variant={"body1"} color={"Grey900"} sx={{ textAlign: "center" }}>
 					If you need further support, reach out to us by emailing{" "}
 					<Link
-						href="mailto:info@thepreventionproject.ca"
+						href="mailto:info@ally.org"
 						sx={{ color: "PrimaryPurple" }}
 					>
-						info@thepreventionproject.ca
+						info@ally.org
 					</Link>{" "}
 					We&apos;re committed to ensuring you feel equipped and empowered to
 					use The Prevention Project effectively.


### PR DESCRIPTION
Following changes:

**In the website footer:**
- Removed: info@thepreventionproject.ca
- Added Ally: info@ally.org
- Added ExEd: hello@exploitationeducation.org
<img width="329" height="323" alt="image" src="https://github.com/user-attachments/assets/7b98f5db-0d6d-4e90-b2f5-fe9e27246999" />

**In Parents & Educations > How to Browse:**
- Contact Us link: info@thepreventionproject.ca -> info@ally.org
<img width="763" height="250" alt="image" src="https://github.com/user-attachments/assets/8b9817fe-fa0a-4714-aeda-e35592bffac2" />

**In Parents & Educations > Questions:**
- info@thepreventionproject.ca -> info@ally.org
<img width="579" height="287" alt="image" src="https://github.com/user-attachments/assets/e4434239-6163-4b14-9c79-b8be730327b5" />

