### PR TITLE
Hide newsletter section in footer

### DIFF
--- a/sections/Footer.tsx
+++ b/sections/Footer.tsx
@@ -79,7 +79,13 @@ const Footer = () => {
                 xl: 3,
               }}
               columns={{ xs: 4, sm: 4, md: 12, lg: 12, xl: 12 }}
-              justifyContent="flex-start"
+              justifyContent={{
+                xs: "flex-start",
+                sm: "flex-start",
+                md: "space-around",
+                lg: "space-around",
+                xl: "space-around"
+              }}
               alignItems="flex-start"
               height="100%"
               style={{


### PR DESCRIPTION
As per Randy's request, I've hidden the newsletter section in the footer of the website. I've chosen to comment it out so we can easily add it back when they have a new solution in place.

<img width="759" height="414" alt="image" src="https://github.com/user-attachments/assets/7d57655c-841c-4f86-982a-160fd7391228" />

I also added `space-around` on larger screens since it was looking empty.
Before:
<img width="1505" height="901" alt="image" src="https://github.com/user-attachments/assets/95652852-f120-418c-a19a-6a2f20c4aaa4" />
After:
<img width="1506" height="813" alt="image" src="https://github.com/user-attachments/assets/f9a232fa-6c2a-4041-8580-e1b49107ffa0" />
After on mobile: Preseve the flex-start since that still looks good
<img width="814" height="895" alt="image" src="https://github.com/user-attachments/assets/861e47ce-2a59-4cdf-9c33-2d22d0f39bf6" />


