### PR TITLE
replace name Sarah Dillon with Eliza Nwachukwu

### DIFF
--- a/sections/Acknowledgements.tsx
+++ b/sections/Acknowledgements.tsx
@@ -63,7 +63,7 @@ const Acknowledgements = () => {
 							>
 								The Laughing Survivor
 							</a>
-							; Sarah Dillon; Carol Todd,{' '}
+							; Eliza Nwachukwu; Carol Todd,{' '}
 							<a
 								href={'https://www.amandatoddlegacy.org/'}
 								target={'_blank'}


### PR DESCRIPTION
Request from Randy: 
> Wherever the name Sarah Dillon is mentioned could you change that name to Eliza Nwachukwu

<img width="1351" height="765" alt="image" src="https://github.com/user-attachments/assets/ece65f70-fcb2-4c47-84bb-526149e850ef" />
